### PR TITLE
Add plausible tracking script

### DIFF
--- a/theme/401.html
+++ b/theme/401.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/404.html
+++ b/theme/404.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[blog].html
+++ b/theme/[blog].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[digest].html
+++ b/theme/[digest].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[dweb-impact-resources].html
+++ b/theme/[dweb-impact-resources].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[project-partners].html
+++ b/theme/[project-partners].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[resource-topics].html
+++ b/theme/[resource-topics].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[resource-type].html
+++ b/theme/[resource-type].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[resources].html
+++ b/theme/[resources].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/[tags].html
+++ b/theme/[tags].html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/about.html
+++ b/theme/about.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/awards.html
+++ b/theme/awards.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/blog.html
+++ b/theme/blog.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
   <style>
 .blog-card_information .w-dyn-item:last-of-type div:last-of-type {

--- a/theme/contact.html
+++ b/theme/contact.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/digest.html
+++ b/theme/digest.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/explore.html
+++ b/theme/explore.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/get-involved.html
+++ b/theme/get-involved.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/index.html
+++ b/theme/index.html
@@ -12,7 +12,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script><style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/layouts/header-content.html
+++ b/theme/layouts/header-content.html
@@ -14,7 +14,8 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/privacy.html
+++ b/theme/privacy.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/resources.html
+++ b/theme/resources.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
   <!--  [Attributes by Finsweet] CMS Filter  -->
   <script async="" src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>

--- a/theme/terms.html
+++ b/theme/terms.html
@@ -14,7 +14,7 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/utility/base.html
+++ b/theme/utility/base.html
@@ -14,7 +14,8 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/utility/base.html
+++ b/theme/utility/base.html
@@ -14,7 +14,6 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-
   <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {

--- a/theme/utility/elements-with-interactions.html
+++ b/theme/utility/elements-with-interactions.html
@@ -14,7 +14,8 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/utility/elements-with-interactions.html
+++ b/theme/utility/elements-with-interactions.html
@@ -14,7 +14,6 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-
   <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {

--- a/theme/utility/modal.html
+++ b/theme/utility/modal.html
@@ -14,7 +14,8 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/utility/modal.html
+++ b/theme/utility/modal.html
@@ -14,7 +14,6 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-
   <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {

--- a/theme/utility/style-guide.html
+++ b/theme/utility/style-guide.html
@@ -14,7 +14,8 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.tagged-events.js"></script>
+
+  <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {
             aspect-ratio: 16 / 9;

--- a/theme/utility/style-guide.html
+++ b/theme/utility/style-guide.html
@@ -14,7 +14,6 @@
   <link href="{{ settings.site.apple_touch_icon | default: "/assets/images/webclip.png" }}" rel="apple-touch-icon">
   <script>document.querySelectorAll('[html\\3A attribute="target|_blank"]').forEach(el => el.target = "_blank")</script>
   <!--  Plausible  -->
-
   <script defer="" data-domain="ffdweb.org" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
   <!--  Plausible  -->
 {{ settings.site.header_additional_content }}{%- include "partials/_site-css-variables" -%}<style>.w-video.w-embed {


### PR DESCRIPTION
This PR adds new Plausible script to track:
- Outbound links
- File downloads
- 404 error pages
- Hashed page paths

[Plausible link here.](https://plausible.io/ffdweb.org/installation?flow=review)